### PR TITLE
Add check for fully supported html template layout pages to getHtmlWriterUtf8

### DIFF
--- a/WEB-INF/classes/gov/noaa/pfel/erddap/Erddap.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/Erddap.java
@@ -76,6 +76,7 @@ import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -23815,19 +23816,28 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
     Writer writer = File2.getBufferedWriterUtf8(out);
 
-    // write the information for this protocol (dataset list table and instructions)
-    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
-    if (!useHtmlTemplates(request)) {
+    // Pages which support full HTML template layouts need to be added here
+    // TODO remove this check once all pages support HTML templating
+    boolean isSupportedHtmlLayoutPage =
+        List.of("legal.html", "outOfDateDatasets.html", "status.html", "subscriptions/index.html")
+            .contains(endOfRequest);
+
+    if (!useHtmlTemplates(request) || !isSupportedHtmlLayoutPage) {
+      // write the information for this protocol (dataset list table and instructions)
+      String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
       writer.write(EDStatic.startHeadHtml(language, tErddapUrl, addToTitle));
       if (String2.isSomething(addToHead)) writer.write("\n" + addToHead);
       writer.write("\n</head>\n");
       writer.write(
           EDStatic.startBodyHtml(request, language, loggedInAs, endOfRequest, queryString));
       writer.write("\n");
+      writer.write(
+          HtmlWidgets.htmlTooltipScript(EDStatic.imageDirUrl(request, loggedInAs, language)));
+      writer.flush(); // Steve Souders says: the sooner you can send some html to user, the better
+    } else {
+      request.setAttribute("SUPPRESS_END_HTML_WRITER", true);
     }
-    writer.write(
-        HtmlWidgets.htmlTooltipScript(EDStatic.imageDirUrl(request, loggedInAs, language)));
-    writer.flush(); // Steve Souder says: the sooner you can send some html to user, the better
+
     return writer;
   }
 
@@ -23855,9 +23865,18 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       throws Throwable {
 
     try (writer) {
-      // end of document
-      writer.write(EDStatic.endBodyHtml(request, language, tErddapUrl, loggedInAs));
-      writer.write("\n</html>\n");
+      // endOfRequest is not available here, so we check for a request
+      // attribute set in getHtmlWriterUtf8 to determine if
+      // we should suppress writing footer content here
+      // (if an html template layout is in use)
+      boolean supressEndHtmlWriter =
+          (Boolean)
+              Objects.requireNonNullElse(request.getAttribute("SUPPRESS_END_HTML_WRITER"), false);
+      if (!useHtmlTemplates(request) || !supressEndHtmlWriter) {
+        // end of document
+        writer.write(EDStatic.endBodyHtml(request, language, tErddapUrl, loggedInAs));
+        writer.write("\n</html>\n");
+      }
 
       // essential
       writer.flush();

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/jte/TemplateHelper.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/jte/TemplateHelper.java
@@ -1,6 +1,8 @@
 package gov.noaa.pfel.erddap.jte;
 
 import com.cohort.util.Calendar2;
+import com.cohort.util.String2;
+import gov.noaa.pfel.coastwatch.util.HtmlWidgets;
 import gov.noaa.pfel.erddap.util.EDMessages.Message;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import java.text.MessageFormat;
@@ -16,5 +18,29 @@ public class TemplateHelper {
 
   public static String getCurrentTimeZulu() {
     return Calendar2.getCurrentISODateTimeStringZulu() + "Z";
+  }
+
+  public static String getEndBodyHtml(String erddapUrl, int language) {
+    // ported from EDStatic.endBodyHtml
+    String s =
+        String2.replaceAll(getMessage(Message.END_BODY_HTML, language), "&erddapUrl;", erddapUrl);
+    if (language > 0) {
+      s =
+          s.replace(
+              "<hr>",
+              """
+        <br><img src="%s/images/TranslatedByGoogle.png" alt="Translated by Google">
+        %s
+        <hr>
+        """
+                  .formatted(
+                      erddapUrl,
+                      HtmlWidgets.htmlTooltipImage(
+                          erddapUrl + "/images/" + EDStatic.messages.questionMarkImageFile,
+                          "?",
+                          EDStatic.translationDisclaimer,
+                          "")));
+    }
+    return s;
   }
 }

--- a/src/main/jte/layout/main.jte
+++ b/src/main/jte/layout/main.jte
@@ -14,23 +14,24 @@
 <title>ERDDAP</title>
 <link rel="shortcut icon" href="${tErddapUrl}/images/favicon.ico">
 <link href="${tErddapUrl}/images/erddap2.css" rel="stylesheet" type="text/css">
-<meta name="viewport" content="width=device-width, initial-scale=1">  
+<meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
-    <table class="compact nowrap" style="width:100%; background-color:#128CB5;">
-  <tr> 
+  <script src="${tErddapUrl}/images/wz_tooltip.js"></script>
+  <table class="compact nowrap" style="width:100%; background-color:#128CB5;">
+  <tr>
     <td style="text-align:center; width:80px;"><a rel="bookmark"
-      href="https://www.noaa.gov/"><img 
-      title="National Oceanic and Atmospheric Administration" 
+      href="https://www.noaa.gov/"><img
+      title="National Oceanic and Atmospheric Administration"
       src="${tErddapUrl}/images/noaab.png" alt="NOAA"
-      style="vertical-align:middle;"></a></td> 
+      style="vertical-align:middle;"></a></td>
     <td style="text-align:left; font-size:x-large; color:#FFFFFF; ">
       <strong>ERDDAP</strong>
       <br><small><small><small>${TemplateHelper.getMessage(Message.EASIER_ACCESS_TO_SCIENTIFIC_DATA,language)}</small></small></small>
-      </td> 
+      </td>
       <!-- need to do further changes at the legal.html -->
-    <td style="text-align:right; font-size:small;"> 
-      &loginInfo; | <select name="language" 
+    <td style="text-align:right; font-size:small;">
+      &loginInfo; | <select name="language"
         onchange="window.location.href='/erddap/' + (this.selectedIndex == 0 ? '' : this[this.selectedIndex].value + '/') + '${endOfRequest}'">
         <option value="en">English</option>
         <option value="bn">বাংলা - Bengali</option>
@@ -63,21 +64,24 @@
         <option value="uk">Українська - Ukrainian</option>
         <option value="ur">اُردُو - Urdu</option>
       </select> &nbsp; &nbsp;
-      <br>${TemplateHelper.getMessage(Message.BROUGHT_TO_YOU_BY,language)} 
+      <br>${TemplateHelper.getMessage(Message.BROUGHT_TO_YOU_BY,language)}
       <a title="National Oceanic and Atmospheric Administration" rel="bookmark"
-      href="https://www.noaa.gov">NOAA</a>  
+      href="https://www.noaa.gov">NOAA</a>
       <a title="National Marine Fisheries Service" rel="bookmark"
-      href="https://www.fisheries.noaa.gov">NMFS</a>  
+      href="https://www.fisheries.noaa.gov">NMFS</a>
       <a title="Southwest Fisheries Science Center" rel="bookmark"
-      href="https://www.fisheries.noaa.gov/about/southwest-fisheries-science-center">SWFSC</a> 
+      href="https://www.fisheries.noaa.gov/about/southwest-fisheries-science-center">SWFSC</a>
       <a title="Environmental Research Division" rel="bookmark"
-      href="https://www.fisheries.noaa.gov/about/environmental-research-division-southwest-fisheries-science-center">ERD</a>  
+      href="https://www.fisheries.noaa.gov/about/environmental-research-division-southwest-fisheries-science-center">ERD</a>
       &nbsp; &nbsp;
-      </td> 
-  </tr> 
+      </td>
+  </tr>
 </table>
 @template.youarehere(youAreHere)
 <!-- Content block -->
-  ${content}
+${content}
+
+$unsafe{TemplateHelper.getEndBodyHtml(tErddapUrl, language)}
+
 </body>
 </html>

--- a/src/main/jte/legal.jte
+++ b/src/main/jte/legal.jte
@@ -11,8 +11,10 @@
     youAreHere=youAreHere,
     endOfRequest=endOfRequest,
     content=@`
-        <div>$unsafe{Legal.getMessage(Message.LEGAL_NOTICES, language)}</div>
-        <div>$unsafe{Legal.getMessage(Message.STANDARD_GENERAL_DISCLAIMER, language)}</div>
-        <div>$unsafe{Legal.getLegal(language,tErddapUrl)}</div>
+        <div class="standard_width">
+            <div>$unsafe{Legal.getMessage(Message.LEGAL_NOTICES, language)}</div>
+            <div>$unsafe{Legal.getMessage(Message.STANDARD_GENERAL_DISCLAIMER, language)}</div>
+            <div>$unsafe{Legal.getLegal(language,tErddapUrl)}</div>
+        </div>
         `
 )

--- a/src/main/jte/subscription.jte
+++ b/src/main/jte/subscription.jte
@@ -18,10 +18,7 @@
         $unsafe{TemplateHelper.getFormated(TemplateHelper.getMessage(Message.SUBSCRIPTION_1_HTML,language), youAreHere.getErddapUrl())}
 
     <p>
-        <strong>
-            ${TemplateHelper.getMessage(Message.OPTIONS,language)}
-            :
-        </strong>
+        <strong>${TemplateHelper.getMessage(Message.OPTIONS,language)}:</strong>
     </p>
     <ul>
         <li>


### PR DESCRIPTION
Add list of pages fully supporting html template layouts to Erddap.getHtmlWriterUtf8 so that unsupported pages continue to write initial content (html, head, and body start) to the writer.

Also handle supression of writer end body html for supported html template layout pages.

Also add wz_tooltip.js to the main.jte and prevent writing it in the writer intialiation for supported layout pages.

Also some minor trailing whitespace cleanup in main.jte and standard width div in legal.jte